### PR TITLE
Fixed windows config, updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ PHP-xxHash
 
 A PHP extension to add support for the [xxHash](https://github.com/Cyan4973/xxHash) fast hashing algorithm.
 
-[xxHash](https://github.com/Cyan4973/xxHash) is an Extremely fast Hash algorithm, running at RAM speed limits. 
+[xxHash](https://github.com/Cyan4973/xxHash) is an Extremely fast Hash algorithm, running at RAM speed limits.
 It successfully completes the [SMHasher](http://code.google.com/p/smhasher/wiki/SMHasher) test suite which evaluates collision, dispersion and randomness qualities of hash functions.
 
 ## PHP7 Compatability
@@ -11,13 +11,22 @@ It successfully completes the [SMHasher](http://code.google.com/p/smhasher/wiki/
 Please note at the moment the master branch should be used for PHP 5.x and develop branch should be used for PHP 7.x
 
 ## Installation Instructions
-
+###Unix:
 ```
    phpize
    ./configure --enable-xxhash
    make
    sudo make install
 ```
+
+###Windows:
+Follow [this guide](https://wiki.php.net/internals/windows/stepbystepbuild) until Compile step 4. Afterwards, run:
+```
+   configure --enable-xxhash=shared
+   nmake
+```
+The library can be found in `C:\php-sdk\phpdev\vc14\x64\php-VERSION-src\x64\Release_TS\php_xxhash.dll`
+
 Don't forget to load the extension in via php.ini or the like.
 
 ## Usage Instructions

--- a/config.m4
+++ b/config.m4
@@ -1,24 +1,9 @@
 dnl $Id$
 dnl config.m4 for extension xxhash
 
-dnl Comments in this file start with the string 'dnl'.
-dnl Remove where necessary. This file will not work
-dnl without editing.
-
-dnl If your extension references something external, use with:
-
-dnl PHP_ARG_WITH(xxhash, for xxhash support,
-dnl Make sure that the comment is aligned:
-dnl [  --with-xxhash             Include xxhash support])
-
-dnl Otherwise use enable:
-
 PHP_ARG_ENABLE(xxhash, whether to enable xxhash support,
-dnl Make sure that the comment is aligned:
 [  --enable-xxhash            Enable xxhash support])
 
 if test "$PHP_XXHASH" != "no"; then
-  dnl Write more examples of tests here...
-
   PHP_NEW_EXTENSION(xxhash, php_xxhash.c, $ext_shared)
 fi

--- a/config.w32
+++ b/config.w32
@@ -1,11 +1,7 @@
 // $Id$
 // vim:ft=javascript
 
-// If your extension references something external, use ARG_WITH
-// ARG_WITH("xxhash", "for xxhash support", "no");
-
-// Otherwise, use ARG_ENABLE
-// ARG_ENABLE("xxhash", "enable xxhash support", "no");
+ARG_ENABLE("xxhash", "enable xxhash support", "no");
 
 if (PHP_XXHASH != "no") {
 	EXTENSION("xxhash", "php_xxhash.c");


### PR DESCRIPTION
Compiling under windows doesn't work without this small modification. I also cleaned up the unix config file and updated the readme file to add windows compilation instructions
